### PR TITLE
Customizable URLs

### DIFF
--- a/Cotter.podspec
+++ b/Cotter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Cotter'
-  s.version          = '1.5.19'
+  s.version          = '1.5.20'
   s.summary          = 'Cotter is the client SDK for Cotter authentication services'
   s.swift_versions   = '5.0'
 

--- a/Example/CotterIOS/AppDelegate.swift
+++ b/Example/CotterIOS/AppDelegate.swift
@@ -45,24 +45,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         CotterWrapper.cotter = Cotter(
             apiSecretKey: apiSecretKey,
             apiKeyID: apiKeyID,
-//            cotterURL: "http://192.168.86.28:1234/api/v0",
+            // cotterURL: "http://192.168.86.28:1234/api/v0",
             cotterURL: "https://www.cotter.app/api/v0",
             userID: "",
             // configuration is an optional argument, remove this below and Cotter app will still function properly
             configuration: [:]
         )
-        
         // if you want to start PINViewControler on startup, use getPINViewController
-//        let vc = CotterWrapper.cotter!.getTransactionPINViewController(hideClose: true, cb: Callback.shared.authCb)
-//        let nav = UINavigationController(rootViewController: vc)
-//        self.window?.rootViewController = nav
-//        self.window?.makeKeyAndVisible()
+        // let vc = CotterWrapper.cotter!.getTransactionPINViewController(hideClose: true, cb: Callback.shared.authCb)
+        // let nav = UINavigationController(rootViewController: vc)
+        // self.window?.rootViewController = nav
+        // self.window?.makeKeyAndVisible()
         
         // the following configuration is optional, only use this if you want to use your own fonts
-//        let customFont = FontObject()
-//        customFont.title = UIFont.systemFont(ofSize: 9.0)
-//        customFont.subtitle = UIFont.boldSystemFont(ofSize: 35.0)
-//        customFont.keypad = UIFont.boldSystemFont(ofSize: 10.0)
+        // let customFont = FontObject()
+        // customFont.title = UIFont.systemFont(ofSize: 9.0)
+        // customFont.subtitle = UIFont.boldSystemFont(ofSize: 35.0)
+        // customFont.keypad = UIFont.boldSystemFont(ofSize: 10.0)
         
         // let lang = Indonesian()
         // lang.setText(for: PINViewControllerKey.navTitle, to: "Hello world!")
@@ -73,19 +72,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         // custom coloring
         let color = ColorSchemeObject(primary: CotterColor.purple, accent: CotterColor.orange)
-        
+
         Cotter.configureWithLaunchOptions(
             launchOptions: launchOptions,
             apiSecretKey: apiSecretKey,
             apiKeyID: apiKeyID,
             configuration: [
-                // "fonts": customFont,
                 "colors": color,
                 "images": img,
+                
+                // Other configuration
+                // "base_url": "http://192.168.86.33:1234/api/v0",
+                // "passwordless_base_url": "https://s.js.cotter.app/app",
                 // "language": lang
+                // "fonts": customFont,
             ]
         )
-        
+            
         // Granting user permission using notification center
         UNUserNotificationCenter.current() // 1
         .requestAuthorization(options: [.alert, .sound, .badge]) { // 2

--- a/Source/Config/Config.swift
+++ b/Source/Config/Config.swift
@@ -31,13 +31,9 @@ class Config: NSObject {
   
     // space configurations
     var baseURL: URL = URL(string: "https://www.cotter.app/api/v0")!
-//    var baseURL: URL = URL(string: "http://192.168.86.33:1234/api/v0")!
     
     // passwordless configurations
     var PLBaseURL: String? = "https://js.cotter.app/app"
-//    var PLBaseURL: String? = "https://s.js.cotter.app/app"
-//    var PLBaseURL: String? = "http://localhost:3000/app"
-//    var PLBaseURL: String? = "http://192.168.86.33:3000/app"
     var PLScheme: String? = "cotter"
     var PLRedirectURL: String? = "cotter://auth"
     

--- a/Source/Cotter.swift
+++ b/Source/Cotter.swift
@@ -329,6 +329,13 @@ public class Cotter {
         if let name = configuration["name"] as! String?, let sendingMethod = configuration["sendingMethod"] as! String?, let sendingDestination = configuration["sendingDestination"] as! String? {
             Config.instance.userInfo = UserInfo(name: name, sendingMethod: sendingMethod, sendingDestination: sendingDestination)
         }
+        
+        if let baseURL = configuration["base_url"] as! String? {
+            Config.instance.baseURL = URL(string: baseURL)!
+        }
+        if let passwordlessBaseURL = configuration["passwordless_base_url"] as! String? {
+            Config.instance.PLBaseURL = passwordlessBaseURL
+        }
     }
     
     // configureWithLaunchOptions configures cotter with notification services (OneSignal)
@@ -350,7 +357,7 @@ public class Cotter {
             Passwordless.shared.checkEvent(clientUserID: userID)
         }
     }
-    
+
     // configureOneSignal configure cotter's onesignal SDK with launchOptions provided
     private static func configureOneSignal(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
         let onesignalInitSettings = [kOSSettingsKeyAutoPrompt: false,


### PR DESCRIPTION
To change the base URL, add an entry to configuration object.

|Key|Default Value|Description|
|----|------------|------------|
|base_url|https://www.cotter.app/api/v0|This is the base URL for Cotter's main server|
|passwordless_base_url|https://js.cotter.app/app|This is the base URL for passwordless login|

Example:
```swift
Cotter.configureWithLaunchOptions(
            launchOptions: launchOptions,
            apiSecretKey: apiSecretKey,
            apiKeyID: apiKeyID,
            configuration: [
                "base_url": "http://192.168.86.33:1234/api/v0",
                "passwordless_base_url": "https://s.js.cotter.app/app",
            ]
        )
```

or for backward compatibility support:

```swift
CotterWrapper.cotter = Cotter(
            apiSecretKey: apiSecretKey,
            apiKeyID: apiKeyID,
            cotterURL: "https://www.cotter.app/api/v0",
            userID: "",
            // configuration is an optional argument, remove this below and Cotter app will still function properly
            configuration: [
                "base_url": "http://192.168.86.33:1234/api/v0",
                "passwordless_base_url": "https://s.js.cotter.app/app",
            ]
        )
```
> Please note that configuration's `base_url` will override cotterURL.